### PR TITLE
Feature/natures-page

### DIFF
--- a/src/app/natures/page.tsx
+++ b/src/app/natures/page.tsx
@@ -1,0 +1,20 @@
+// src/app/natures/page.tsx
+import { NaturesGrid } from "@/components/NaturesGrid";
+import { NatureController } from "@/controllers/Nature.controller";
+
+export default async function NaturesPage() {
+  const controller = new NatureController();
+  const { data: natures, error } = await controller.getNaturesList();
+
+  if (error) return <div>Error: {error}</div>;
+  if (!natures) return <div>Loading...</div>;
+
+  return (
+    <main className="min-h-screen bg-white">
+      <div className="container mx-auto p-4">
+        <h1 className="text-2xl font-bold mb-6">Pokémon Natures</h1>
+        <NaturesGrid natures={natures} />
+      </div>
+    </main>
+  );
+}

--- a/src/app/natures/page.tsx
+++ b/src/app/natures/page.tsx
@@ -11,7 +11,7 @@ export default async function NaturesPage() {
 
   return (
     <main className="min-h-screen bg-white">
-      <div className="container mx-auto p-4">
+      <div className="container mx-auto p-4 text-black">
         <h1 className="text-2xl font-bold mb-6">Pokémon Natures</h1>
         <NaturesGrid natures={natures} />
       </div>

--- a/src/components/NatureStatsChart.tsx
+++ b/src/components/NatureStatsChart.tsx
@@ -1,0 +1,28 @@
+// src/components/NatureStatsChart.tsx
+interface NatureStatsProps {
+  increasedStat: string | null;
+  decreasedStat: string | null;
+}
+
+export function NatureStatsChart({ increasedStat, decreasedStat }: NatureStatsProps) {
+  const stats = ['Attack', 'Defense', 'Sp. Atk', 'Sp. Def', 'Speed'];
+  
+  return (
+    <div className="grid grid-cols-5 gap-1 mt-2">
+      {stats.map((stat) => (
+        <div key={stat} className="text-center">
+          <div className="text-xs text-gray-600">{stat}</div>
+          <div 
+            className={`h-2 rounded mt-1 ${
+              stat === increasedStat 
+                ? 'bg-green-500' 
+                : stat === decreasedStat 
+                  ? 'bg-red-500' 
+                  : 'bg-gray-200'
+            }`}
+          />
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/src/components/NaturesGrid.tsx
+++ b/src/components/NaturesGrid.tsx
@@ -1,0 +1,41 @@
+// src/components/NaturesGrid.tsx
+import { Nature } from "@/models/Nature.model";
+import { ArrowUpIcon, ArrowDownIcon } from 'lucide-react';
+
+export function NaturesGrid({ natures }: { natures: Nature[] }) {
+  return (
+    <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-5">
+      {natures.map((nature) => (
+        <div
+          key={nature.id}
+          className="border rounded-lg p-4 hover:shadow-lg transition-shadow"
+        >
+          <h2 className="text-lg font-semibold capitalize mb-3">
+            {nature.name} Nature
+          </h2>
+          
+          <div className="space-y-2">
+            {nature.increasedStat && (
+              <div className="flex items-center gap-2 text-green-600">
+                <ArrowUpIcon size={16} />
+                <span>{nature.increasedStat}</span>
+              </div>
+            )}
+            
+            {nature.decreasedStat && (
+              <div className="flex items-center gap-2 text-red-600">
+                <ArrowDownIcon size={16} />
+                <span>{nature.decreasedStat}</span>
+              </div>
+            )}
+          </div>
+
+          <div className="mt-3 text-sm text-gray-600">
+            <div>Likes: {nature.likesFlavor}</div>
+            <div>Dislikes: {nature.hatesFlavor}</div>
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/src/components/NaturesGrid.tsx
+++ b/src/components/NaturesGrid.tsx
@@ -1,41 +1,31 @@
 // src/components/NaturesGrid.tsx
 import { Nature } from "@/models/Nature.model";
-import { ArrowUpIcon, ArrowDownIcon } from 'lucide-react';
+import { NatureStatsChart } from "./NatureStatsChart";
+
 
 export function NaturesGrid({ natures }: { natures: Nature[] }) {
-  return (
-    <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-5">
-      {natures.map((nature) => (
-        <div
-          key={nature.id}
-          className="border rounded-lg p-4 hover:shadow-lg transition-shadow"
-        >
-          <h2 className="text-lg font-semibold capitalize mb-3">
-            {nature.name} Nature
-          </h2>
-          
-          <div className="space-y-2">
-            {nature.increasedStat && (
-              <div className="flex items-center gap-2 text-green-600">
-                <ArrowUpIcon size={16} />
-                <span>{nature.increasedStat}</span>
-              </div>
-            )}
+    return (
+      <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-5">
+        {natures.map((nature) => (
+          <div
+            key={nature.id}
+            className="border rounded-lg p-4 hover:shadow-lg transition-shadow"
+          >
+            <h2 className="text-lg font-semibold capitalize mb-3">
+              {nature.name} Nature
+            </h2>
             
-            {nature.decreasedStat && (
-              <div className="flex items-center gap-2 text-red-600">
-                <ArrowDownIcon size={16} />
-                <span>{nature.decreasedStat}</span>
-              </div>
-            )}
+            <NatureStatsChart 
+              increasedStat={nature.increasedStat}
+              decreasedStat={nature.decreasedStat}
+            />
+  
+            <div className="mt-3 text-sm text-gray-600">
+              <div>Likes: <span className="capitalize">{nature.likesFlavor}</span></div>
+              <div>Dislikes: <span className="capitalize">{nature.hatesFlavor}</span></div>
+            </div>
           </div>
-
-          <div className="mt-3 text-sm text-gray-600">
-            <div>Likes: {nature.likesFlavor}</div>
-            <div>Dislikes: {nature.hatesFlavor}</div>
-          </div>
-        </div>
-      ))}
-    </div>
-  );
-}
+        ))}
+      </div>
+    );
+  }

--- a/src/controllers/Nature.controller.ts
+++ b/src/controllers/Nature.controller.ts
@@ -1,0 +1,23 @@
+// src/controllers/Nature.controller.ts
+import { NatureModel, Nature } from '@/models/Nature.model';
+
+export class NatureController {
+  private model: NatureModel;
+
+  constructor() {
+    this.model = new NatureModel();
+  }
+
+  async getNaturesList(): Promise<{
+    data: Nature[] | null;
+    error: string | null;
+  }> {
+    try {
+      const natures = await this.model.getAllNatures();
+      return { data: natures, error: null };
+    } catch (err) {
+      console.error('Controller error:', err);
+      return { data: null, error: 'Failed to load natures' };
+    }
+  }
+}

--- a/src/models/Nature.model.ts
+++ b/src/models/Nature.model.ts
@@ -1,0 +1,68 @@
+interface NatureApiResponse {
+    id: number;
+    name: string;
+    increased_stat: {
+      name: string;
+    } | null;
+    decreased_stat: {
+      name: string;
+    } | null;
+    likes_flavor: {
+      name: string;
+    };
+    hates_flavor: {
+      name: string;
+    };
+  }
+  
+  export interface Nature {
+    id: number;
+    name: string;
+    increasedStat: string | null;
+    decreasedStat: string | null;
+    likesFlavor: string;
+    hatesFlavor: string;
+  }
+  
+  export class NatureModel {
+    private formatStatName(stat: string): string {
+      const statNames: { [key: string]: string } = {
+        'attack': 'Attack',
+        'defense': 'Defense',
+        'special-attack': 'Sp. Atk',
+        'special-defense': 'Sp. Def',
+        'speed': 'Speed'
+      };
+      return statNames[stat] || stat;
+    }
+  
+    async getAllNatures(): Promise<Nature[]> {
+      try {
+        const response = await fetch('https://pokeapi.co/api/v2/nature?limit=25');
+        const data = await response.json();
+        
+        const natures = await Promise.all(
+          data.results.map(async (nature: { name: string; url: string }) => {
+            const natureResponse = await fetch(nature.url);
+            const natureData: NatureApiResponse = await natureResponse.json();
+  
+            return {
+              id: natureData.id,
+              name: natureData.name,
+              increasedStat: natureData.increased_stat ? 
+                this.formatStatName(natureData.increased_stat.name) : null,
+              decreasedStat: natureData.decreased_stat ? 
+                this.formatStatName(natureData.decreased_stat.name) : null,
+              likesFlavor: natureData.likes_flavor.name,
+              hatesFlavor: natureData.hates_flavor.name
+            };
+          })
+        );
+  
+        return natures;
+      } catch (error) {
+        console.error('Failed to fetch natures:', error);
+        return [];
+      }
+    }
+  }

--- a/src/models/Nature.model.ts
+++ b/src/models/Nature.model.ts
@@ -1,3 +1,4 @@
+// src/models/Nature.model.ts
 interface NatureApiResponse {
     id: number;
     name: string;
@@ -9,10 +10,10 @@ interface NatureApiResponse {
     } | null;
     likes_flavor: {
       name: string;
-    };
+    } | null;
     hates_flavor: {
       name: string;
-    };
+    } | null;
   }
   
   export interface Nature {
@@ -20,8 +21,8 @@ interface NatureApiResponse {
     name: string;
     increasedStat: string | null;
     decreasedStat: string | null;
-    likesFlavor: string;
-    hatesFlavor: string;
+    likesFlavor: string | null;
+    hatesFlavor: string | null;
   }
   
   export class NatureModel {
@@ -53,8 +54,8 @@ interface NatureApiResponse {
                 this.formatStatName(natureData.increased_stat.name) : null,
               decreasedStat: natureData.decreased_stat ? 
                 this.formatStatName(natureData.decreased_stat.name) : null,
-              likesFlavor: natureData.likes_flavor.name,
-              hatesFlavor: natureData.hates_flavor.name
+              likesFlavor: natureData.likes_flavor?.name || null,
+              hatesFlavor: natureData.hates_flavor?.name || null
             };
           })
         );


### PR DESCRIPTION
# Add Natures Page with Stat Visualization

Adds `/natures` route with:
- Complete list of all 25 Pokémon natures
- Visual indicators for increased/decreased stats
