### PR TITLE
Feature/page-fix

### DIFF
--- a/src/app/parties/page.tsx
+++ b/src/app/parties/page.tsx
@@ -4,7 +4,7 @@ import { Suspense } from "react";
 
 export default function PartiesPage() {
   return (
-    <main className="min-h-screen bg-white">
+    <main className="min-h-screen bg-white text-black">
       <div className="container mx-auto p-4">
         <h1 className="text-2xl font-bold mb-6">Pokémon Parties</h1>
         <Suspense fallback={<div>Loading...</div>}>

--- a/src/app/pokedex/page.tsx
+++ b/src/app/pokedex/page.tsx
@@ -1,10 +1,30 @@
+// src/app/pokedex/page.tsx
+"use client";
+
+import { useEffect, useState } from 'react';
 import { PokemonController } from "@/controllers/Pokemon.controller";
 import { LoadingState } from "@/components/LoadingState";
 import { PokemonList } from "@/components/PokemonList";
+import type { Pokemon } from "@/models/Pokemon.model";
 
-export default async function PokemonGridPage() {
-  const controller = new PokemonController();
-  const { data: pokemon, error } = await controller.getPokemonList();
+export default function PokemonGridPage() {
+  const [pokemon, setPokemon] = useState<Pokemon[] | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const loadPokemon = async () => {
+      const controller = new PokemonController();
+      const { data, error } = await controller.getPokemonList();
+      
+      if (error) {
+        setError(error);
+      } else {
+        setPokemon(data);
+      }
+    };
+
+    loadPokemon();
+  }, []);
 
   if (error) return <div>Error: {error}</div>;
   if (!pokemon) return <LoadingState />;

--- a/src/components/PokemonGrid.tsx
+++ b/src/components/PokemonGrid.tsx
@@ -12,9 +12,10 @@ import { DatabaseService } from '@/services/Database.service';
 interface PokemonGridProps {
   pokemon: Pokemon[];
   selectedGameId: number | null;
+  dexNumbers: { [key: number]: number };
 }
 
-export function PokemonGrid({ pokemon, selectedGameId }: PokemonGridProps) {
+export function PokemonGrid({ pokemon, selectedGameId, dexNumbers }: PokemonGridProps) {
   const { username } = useAuth();
   const [caughtService] = useState<IDatabaseService>(() => 
     process.env.NEXT_PUBLIC_USE_LOCAL_STORAGE === 'true' 
@@ -24,7 +25,6 @@ export function PokemonGrid({ pokemon, selectedGameId }: PokemonGridProps) {
   const [caughtPokemon, setCaughtPokemon] = useState<number[]>([]);
   const [isLoading, setIsLoading] = useState<{ [key: number]: boolean }>({});
 
-  // Load caught Pokemon once when game/user changes
   useEffect(() => {
     const loadCaughtPokemon = async () => {
       if (selectedGameId && username) {
@@ -70,6 +70,7 @@ export function PokemonGrid({ pokemon, selectedGameId }: PokemonGridProps) {
       {pokemon.map((p) => {
         const isCaught = caughtPokemon.includes(p.id);
         const isProcessing = isLoading[p.id];
+        const dexNumber = selectedGameId && dexNumbers[p.id] ? dexNumbers[p.id] : p.id;
         
         return (
           <div
@@ -82,7 +83,12 @@ export function PokemonGrid({ pokemon, selectedGameId }: PokemonGridProps) {
           >
             <Link href={`/pokemon/${p.id}`} className="block">
               <p className="absolute top-2 left-2 text-sm text-gray-500">
-                #{p.id.toString().padStart(4, "0")}
+                #{dexNumber.toString().padStart(4, "0")}
+                {selectedGameId && dexNumbers[p.id] && (
+                  <span className="text-xs ml-2 text-gray-400">
+                    (#{p.id})
+                  </span>
+                )}
               </p>
               
               {isCaught && (

--- a/src/components/SelectPokemonModal.tsx
+++ b/src/components/SelectPokemonModal.tsx
@@ -46,11 +46,10 @@ export function SelectPokemonModal({
       if (pokemonResult.error) throw new Error(pokemonResult.error);
       if (versionResult.error) throw new Error(versionResult.error);
       if (!pokemonResult.data || !versionResult.data) throw new Error('Failed to load data');
-      if (!versionResult.data) throw new Error('Failed to load version data');
 
       // Filter Pokemon available in this game version
       const availablePokemon = pokemonResult.data.filter(p => 
-        versionResult.data!.includes(p.id)  // Using ! to assert non-null
+        versionResult.data!.includes(p.id)
       );
 
       setPokemon(availablePokemon);
@@ -72,7 +71,7 @@ export function SelectPokemonModal({
 
   return (
     <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50">
-      <div className="bg-white rounded-lg p-6 max-w-2xl w-full max-h-[80vh] relative">
+      <div className="bg-white rounded-lg p-6 w-full max-w-4xl max-h-[90vh] relative">
         <button
           onClick={onClose}
           className="absolute top-4 right-4 text-gray-500 hover:text-gray-700"
@@ -89,24 +88,26 @@ export function SelectPokemonModal({
         ) : error ? (
           <div className="text-red-500 text-center py-8">{error}</div>
         ) : (
-          <div className="grid grid-cols-4 gap-4 mt-4 max-h-[60vh] overflow-y-auto">
-            {filteredPokemon.map((p) => (
-              <button
-                key={p.id}
-                onClick={() => onSelect(p.id)}
-                className="p-2 border rounded-lg hover:bg-gray-50 text-center"
-              >
-                <Image
-                  src={p.sprite}
-                  alt={p.name}
-                  width={64}
-                  height={64}
-                  className="mx-auto"
-                />
-                <p className="mt-1 text-sm capitalize">{p.name}</p>
-                <p className="text-xs text-gray-500">#{p.id}</p>
-              </button>
-            ))}
+          <div className="overflow-y-auto mt-4" style={{ maxHeight: 'calc(90vh - 180px)' }}>
+            <div className="grid grid-cols-4 sm:grid-cols-5 md:grid-cols-6 lg:grid-cols-8 gap-4">
+              {filteredPokemon.map((p) => (
+                <button
+                  key={p.id}
+                  onClick={() => onSelect(p.id)}
+                  className="p-2 border rounded-lg hover:bg-gray-50 text-center"
+                >
+                  <Image
+                    src={p.sprite}
+                    alt={p.name}
+                    width={64}
+                    height={64}
+                    className="mx-auto"
+                  />
+                  <p className="mt-1 text-sm capitalize">{p.name}</p>
+                  <p className="text-xs text-gray-500">#{p.id}</p>
+                </button>
+              ))}
+            </div>
           </div>
         )}
       </div>

--- a/src/controllers/Game.Controller.ts
+++ b/src/controllers/Game.Controller.ts
@@ -1,5 +1,5 @@
 // src/controllers/Game.controller.ts
-import { GameModel, Game } from '@/models/Game.model';
+import { GameModel, Game, VersionGroupResponse, VersionPokemonResponse } from '@/models/Game.model';
 
 export class GameController {
   private model: GameModel;
@@ -8,55 +8,39 @@ export class GameController {
     this.model = new GameModel();
   }
 
-  /**
-   * Gets all version groups sorted by generation
-   */
-  async getVersionGroups(): Promise<{
-    data: Game[] | null;
-    error: string | null;
-  }> {
+  async getVersionGroups(): Promise<VersionGroupResponse> {
     try {
       const games = await this.model.getVersionGroups();
-      
-      // Sort games by generation and group
-      const sortedGames = games.sort((a, b) => {
-        const genA = parseInt(a.versionGroup.split('-')[1]);
-        const genB = parseInt(b.versionGroup.split('-')[1]);
-        
-        if (genA === genB) {
-          return a.id - b.id;
-        }
-        return genA - genB;
-      });
-
-      return { data: sortedGames, error: null };
+      return { data: games, error: null };
     } catch (err) {
       console.error('Controller error:', err);
       return { data: null, error: 'Failed to load game versions' };
     }
   }
 
-  /**
-   * Gets Pokemon available in a specific version group
-   */
-  async getVersionGroupPokemon(groupId: number): Promise<{
-    data: number[] | null;
-    error: string | null;
-  }> {
+  async getVersionGroupPokemon(groupId: number): Promise<VersionPokemonResponse> {
     try {
-      const { data: games } = await this.getVersionGroups();
-      if (!games) {
-        throw new Error('No games data available');
-      }
-
-      const game = games.find(g => g.id === groupId);
+      const games = await this.model.getVersionGroups();
+      const game = games.find((g: Game) => g.id === groupId);
+      
       if (!game) {
         throw new Error(`Version group ${groupId} not found`);
       }
 
-      return { data: game.availablePokemon, error: null };
+      // Create mapping of national dex numbers to regional dex numbers
+      const dexNumbers = game.availablePokemon.reduce<{ [key: number]: number }>((acc, pokemon) => {
+        acc[pokemon.id] = pokemon.entryNumber;
+        return acc;
+      }, {});
+
+      return { 
+        data: game.availablePokemon.map(p => p.id), 
+        error: null,
+        dexNumbers
+      };
     } catch (err) {
-      console.error('Controller error:', err);
+      const error = err instanceof Error ? err.message : 'Failed to load Pokémon';
+      console.error('Controller error:', error);
       return { 
         data: null, 
         error: `Failed to load Pokémon for version group ${groupId}`
@@ -64,17 +48,14 @@ export class GameController {
     }
   }
 
-  /**
-   * Groups games by their generation
-   */
   getGamesByGeneration(games: Game[]): { [key: string]: Game[] } {
-    return games.reduce((acc, game) => {
+    return games.reduce<{ [key: string]: Game[] }>((acc, game) => {
       const gen = game.versionGroup;
       if (!acc[gen]) {
         acc[gen] = [];
       }
       acc[gen].push(game);
       return acc;
-    }, {} as { [key: string]: Game[] });
+    }, {});
   }
 }

--- a/src/controllers/Pokemon.controller.ts
+++ b/src/controllers/Pokemon.controller.ts
@@ -5,7 +5,7 @@ export class PokemonController {
   private model: PokemonModel;
 
   constructor() {
-    this.model = new PokemonModel();
+    this.model = PokemonModel.getInstance();  // Use singleton instance
   }
 
   async getPokemonList(): Promise<{
@@ -19,5 +19,9 @@ export class PokemonController {
       console.error('Controller error:', err);
       return { data: null, error: 'Failed to load Pokemon' };
     }
+  }
+
+  clearCache(): void {
+    this.model.clearCache();
   }
 }

--- a/src/models/Game.model.ts
+++ b/src/models/Game.model.ts
@@ -1,66 +1,88 @@
 // src/models/Game.model.ts
-/**
- * Interfaces for PokeAPI version group data
- */
-export interface VersionGroup {
-    id: number;
+interface PokemonEntry {
+  entry_number: number;
+  pokemon_species: {
     name: string;
-    generation: {
-      name: string;
-    };
-    pokedexes: {
-      url: string;
-    }[];
-  }
-  
-  /**
-   * Represents a game version with its available Pokemon
-   */
-  export interface Game {
-    id: number;
+    url: string;
+  };
+}
+
+interface PokedexApiResponse {
+  pokemon_entries: PokemonEntry[];
+}
+
+interface VersionGroup {
+  id: number;
+  name: string;
+  generation: {
     name: string;
-    versionGroup: string;
-    availablePokemon: number[];
+  };
+  pokedexes: {
+    url: string;
+  }[];
+}
+
+export interface Game {
+  id: number;
+  name: string;
+  versionGroup: string;
+  availablePokemon: {
+    id: number;          // National dex number
+    entryNumber: number; // Regional dex number
+  }[];
+}
+
+export interface VersionGroupResponse {
+  data: Game[] | null;
+  error: string | null;
+}
+
+export interface VersionPokemonResponse {
+  data: number[] | null;
+  error: string | null;
+  dexNumbers?: { [key: number]: number }; // Maps national dex ID to regional dex number
+}
+
+export class GameModel {
+  private baseUrl = 'https://pokeapi.co/api/v2';
+
+  private extractIdFromUrl(url: string): number {
+    const matches = url.match(/\/(\d+)\/?$/);
+    return matches ? parseInt(matches[1], 10) : 0;
   }
-  
-  export class GameModel {
-    private baseUrl = 'https://pokeapi.co/api/v2';
-  
-    /**
-     * Fetches all version groups and their available Pokemon from PokeAPI
-     * @returns Promise<Game[]> Array of games with their available Pokemon
-     */
-    async getVersionGroups(): Promise<Game[]> {
-      try {
-        const response = await fetch(`${this.baseUrl}/version-group`);
-        const data = await response.json();
+
+  async getVersionGroups(): Promise<Game[]> {
+    try {
+      const response = await fetch(`${this.baseUrl}/version-group`);
+      const data: { results: Array<{ url: string }> } = await response.json();
+      
+      return Promise.all(data.results.map(async (group: { url: string }) => {
+        const groupResponse = await fetch(group.url);
+        const groupData: VersionGroup = await groupResponse.json();
         
-        return Promise.all(data.results.map(async (group: { url: string }) => {
-          const groupResponse = await fetch(group.url);
-          const groupData: VersionGroup = await groupResponse.json();
+        const pokedexUrl = groupData.pokedexes[0]?.url;
+        let availablePokemon: Game['availablePokemon'] = [];
+        
+        if (pokedexUrl) {
+          const pokedexResponse = await fetch(pokedexUrl);
+          const pokedexData: PokedexApiResponse = await pokedexResponse.json();
           
-          // Get the first pokedex for this version group
-          const pokedexUrl = groupData.pokedexes[0]?.url;
-          let availablePokemon: number[] = [];
-          
-          if (pokedexUrl) {
-            const pokedexResponse = await fetch(pokedexUrl);
-            const pokedexData = await pokedexResponse.json();
-            availablePokemon = pokedexData.pokemon_entries.map(
-              (entry: { entry_number: number }) => entry.entry_number
-            );
-          }
-          
-          return {
-            id: groupData.id,
-            name: groupData.name.replace('-', ' ').toUpperCase(),
-            versionGroup: groupData.generation.name,
-            availablePokemon
-          };
-        }));
-      } catch (error) {
-        console.error('Failed to fetch version groups:', error);
-        return [];
-      }
+          availablePokemon = pokedexData.pokemon_entries.map(entry => ({
+            id: this.extractIdFromUrl(entry.pokemon_species.url),
+            entryNumber: entry.entry_number
+          }));
+        }
+        
+        return {
+          id: groupData.id,
+          name: groupData.name.replace('-', ' ').toUpperCase(),
+          versionGroup: groupData.generation.name,
+          availablePokemon
+        };
+      }));
+    } catch (error) {
+      console.error('Failed to fetch version groups:', error);
+      return [];
     }
   }
+}

--- a/src/models/Pokemon.model.ts
+++ b/src/models/Pokemon.model.ts
@@ -1,64 +1,188 @@
 // src/models/Pokemon.model.ts
 interface PokemonApiResponse {
-    results: {
-      name: string;
-      url: string;
-    }[];
-  }
-  
-  interface PokemonTypeData {
-    slot: number;
-    type: {
-      name: string;
-      url: string;
-    };
-  }
-  
-
-  export interface Pokemon {
-    id: number;
+  count: number;
+  results: {
     name: string;
-    sprite: string;
-    types: string[];  // New field
-  }
-  
-  export class PokemonModel {
-    private async getPokemonTypes(id: number): Promise<string[]> {
-      try {
-        const response = await fetch(`https://pokeapi.co/api/v2/pokemon/${id}`);
-        const data = await response.json();
-        return data.types.map((type: PokemonTypeData) => type.type.name);
-      } catch (error) {
-        console.error(`Failed to fetch types for Pokemon ${id}:`, error);
-        return [];
-      }
+    url: string;
+  }[];
+}
+
+interface PokemonTypeData {
+  slot: number;
+  type: {
+    name: string;
+    url: string;
+  };
+}
+
+export interface Pokemon {
+  id: number;
+  name: string;
+  sprite: string;
+  types: string[];
+}
+
+export class PokemonModel {
+  private static instance: PokemonModel;
+  private pokemonCache: Pokemon[] | null = null;
+  private fetchPromise: Promise<Pokemon[]> | null = null;
+  private readonly CACHE_KEY = 'pokemon-cache';
+  private readonly CACHE_TIMESTAMP_KEY = 'pokemon-cache-timestamp';
+  private readonly CACHE_DURATION = 24 * 60 * 60 * 1000; // 24 hours in milliseconds
+
+  public static getInstance(): PokemonModel {
+    if (!PokemonModel.instance) {
+      PokemonModel.instance = new PokemonModel();
     }
-  
-    async getAllPokemon(limit: number = 10): Promise<Pokemon[]> {
+    return PokemonModel.instance;
+  }
+
+  private constructor() {
+    // Try to load cache from localStorage on instantiation
+    this.loadFromLocalStorage();
+  }
+
+  private isServer(): boolean {
+    return typeof window === 'undefined';
+  }
+
+  private loadFromLocalStorage(): void {
+    if (this.isServer()) return;
+
+    try {
+      const timestamp = window.localStorage.getItem(this.CACHE_TIMESTAMP_KEY);
+      const cacheAge = timestamp ? Date.now() - parseInt(timestamp) : Infinity;
+
+      if (cacheAge < this.CACHE_DURATION) {
+        const cached = window.localStorage.getItem(this.CACHE_KEY);
+        if (cached) {
+          this.pokemonCache = JSON.parse(cached);
+          console.log('Loaded Pokemon from localStorage cache');
+        }
+      } else if (timestamp) {
+        // Clear expired cache
+        window.localStorage.removeItem(this.CACHE_KEY);
+        window.localStorage.removeItem(this.CACHE_TIMESTAMP_KEY);
+        console.log('Cleared expired Pokemon cache');
+      }
+    } catch (error) {
+      console.error('Error loading from localStorage:', error);
+    }
+  }
+
+  private saveToLocalStorage(pokemon: Pokemon[]): void {
+    if (this.isServer()) return;
+
+    try {
+      window.localStorage.setItem(this.CACHE_KEY, JSON.stringify(pokemon));
+      window.localStorage.setItem(this.CACHE_TIMESTAMP_KEY, Date.now().toString());
+      console.log('Saved Pokemon to localStorage cache');
+    } catch (error) {
+      console.error('Error saving to localStorage:', error);
+    }
+  }
+
+  private async fetchPokemonBatch(urls: string[]): Promise<Pokemon[]> {
+    const pokemonDetails = await Promise.allSettled(
+      urls.map(async (url) => {
+        try {
+          const response = await fetch(url);
+          if (!response.ok) throw new Error(`HTTP error! status: ${response.status}`);
+          const data = await response.json();
+          return {
+            id: data.id,
+            name: data.name,
+            sprite: `https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/${data.id}.png`,
+            types: data.types.map((t: PokemonTypeData) => t.type.name)
+          };
+        } catch (error) {
+          console.error(`Failed to fetch Pokemon from ${url}:`, error);
+          return null;
+        }
+      })
+    );
+
+    return pokemonDetails
+      .filter((result): result is PromiseFulfilledResult<Pokemon | null> => 
+        result.status === 'fulfilled'
+      )
+      .map(result => result.value)
+      .filter((pokemon): pokemon is Pokemon => pokemon !== null);
+  }
+
+  async getAllPokemon(): Promise<Pokemon[]> {
+    // Return cached results if available
+    if (this.pokemonCache) {
+      console.log('Returning in-memory cached Pokemon list');
+      return this.pokemonCache;
+    }
+
+    // If there's already a fetch in progress, return that promise
+    if (this.fetchPromise) {
+      console.log('Fetch already in progress, returning existing promise');
+      return this.fetchPromise;
+    }
+
+    console.log('Starting new Pokemon fetch...');
+    const startTime = Date.now();
+
+    this.fetchPromise = (async () => {
       try {
-        const response = await fetch(
-          `https://pokeapi.co/api/v2/pokemon?limit=${limit}`
-        );
-        const data = await response.json() as PokemonApiResponse;
+        // Get total count first
+        const initialResponse = await fetch('https://pokeapi.co/api/v2/pokemon?limit=1');
+        if (!initialResponse.ok) throw new Error(`HTTP error! status: ${initialResponse.status}`);
+        const initialData = await initialResponse.json() as PokemonApiResponse;
+        const totalCount = initialData.count;
+        console.log(`Total Pokemon to fetch: ${totalCount}`);
+
+        // Get all Pokemon URLs in one request
+        const fullListResponse = await fetch(`https://pokeapi.co/api/v2/pokemon?limit=${totalCount}`);
+        if (!fullListResponse.ok) throw new Error(`HTTP error! status: ${fullListResponse.status}`);
+        const fullListData = await fullListResponse.json() as PokemonApiResponse;
+
+        // Process in larger parallel batches
+        const batchSize = 30;
+        const allPokemon: Pokemon[] = [];
+        const totalBatches = Math.ceil(fullListData.results.length / batchSize);
         
-        // Fetch types for each Pokemon
-        const pokemonWithTypes = await Promise.all(
-          data.results.map(async (pokemon, index) => {
-            const id = index + 1;
-            const types = await this.getPokemonTypes(id);
-            return {
-              id,
-              name: pokemon.name,
-              sprite: `https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/${id}.png`,
-              types
-            };
-          })
-        );
+        for (let i = 0; i < fullListData.results.length; i += batchSize) {
+          const batch = fullListData.results.slice(i, i + batchSize);
+          const currentBatch = Math.floor(i / batchSize) + 1;
+          console.log(`Fetching batch ${currentBatch}/${totalBatches}`);
+          
+          const batchResults = await this.fetchPokemonBatch(batch.map(p => p.url));
+          allPokemon.push(...batchResults);
+
+          const progress = ((allPokemon.length / totalCount) * 100).toFixed(1);
+          console.log(`Progress: ${allPokemon.length}/${totalCount} (${progress}%)`);
+        }
+
+        const sorted = allPokemon.sort((a, b) => a.id - b.id);
         
-        return pokemonWithTypes;
+        const totalTime = ((Date.now() - startTime) / 1000).toFixed(1);
+        console.log(`Fetch completed in ${totalTime}s!`);
+
+        // Cache the results both in memory and localStorage
+        this.pokemonCache = sorted;
+        this.saveToLocalStorage(sorted);
+        return sorted;
       } catch (error) {
         console.error('Failed to fetch Pokemon:', error);
-        return [];
+        throw error;
+      } finally {
+        this.fetchPromise = null;
       }
+    })();
+
+    return this.fetchPromise;
+  }
+
+  clearCache(): void {
+    this.pokemonCache = null;
+    if (!this.isServer()) {
+      window.localStorage.removeItem(this.CACHE_KEY);
+      window.localStorage.removeItem(this.CACHE_TIMESTAMP_KEY);
+      console.log('Pokemon cache cleared (both memory and localStorage)');
     }
   }
+}


### PR DESCRIPTION
instead of merging first just checkout the branch, or whatever the right term is but change to it on vscode to try it out and let me know if you find any bugs i mightve missed stuff still. I went back a couple commits and redid the page thing. 
- Now just attempts to load all pokemon at once instead of pagination
- Takes a bit but saves to LocalStorage so it doesn't need to load them again
- Works for both the select modal and pokedex page
- While I was at it noticed the game version dex entries didnt match the overall dex entries so had to fix that
- Game version filter now displays correct entries in the correct order with their overall dex number next to it